### PR TITLE
using odinsmr dockerhub registry

### DIFF
--- a/Build_scripts/create_qsmr_project.sh
+++ b/Build_scripts/create_qsmr_project.sh
@@ -40,10 +40,10 @@ usage ()
                              (a further selection can be made by the optional start_day and end_day options)
                            QSMR_PATH="/home/bengt/work/qsmr"
                              path to qsmr repo
-                             (git clone http://phabricator.molflow.com/diffusion/QQ/qsmr.git)
+                             (git clone git@github.com:Odin-SMR/qsmr.git)
                            QSMRDATA_PATH="/home/bengt/work/qsmr-data"
                              path to qsmr-data repo
-                             (git clone http://phabricator.molflow.com/diffusion/QQD/qsmr-data.git)
+                             (git clone git@github.com:Odin-SMR/qsmr-data.git)
 
   Application options:
   -d, --deadline         deadline of project (used to set priority)
@@ -65,7 +65,6 @@ create_qsmr_worker_image()
   INVMODE=$4
   WORKERIMGTAG=$5
   #copy most recent compiled qsmr package
-  #compiled_qsmr_package_url="${JENKINS_ROOT}/job/qsmr_compile_matlab/lastSuccessfulBuild/artifact/Build_scripts/mcr/qsmr.tar.gz"
   compiled_qsmr_package_url="http://odin.rss.chalmers.se/qsmr/qsmr.tar.gz"
   curl -L $compiled_qsmr_package_url -o "${QSMR_PATH}/Build_scripts/docker/qsmr.tar.gz"
   #copy most recent copiled qsmr-data package
@@ -171,7 +170,7 @@ if [ "$WORKER_IMAGE" == " " ]; then
     validate_project_name $PROJECT_NAME
     WORKER_IMAGE_TAG="qsmr_${INVMODE}_${FREQMODE}_${PROJECT_NAME}_${YYMMDD}"
     create_qsmr_worker_image $QSMR_PATH $QSMRDATA_PATH $FREQMODE $INVMODE $WORKER_IMAGE_TAG
-    WORKER_IMAGE="molflow/u-jobs:${WORKER_IMAGE_TAG}"
+    WORKER_IMAGE="odinsmr/u-jobs:${WORKER_IMAGE_TAG}"
 else
     echo "Use image ${WORKER_IMAGE}"
 fi

--- a/Build_scripts/docker/build_worker_image.sh
+++ b/Build_scripts/docker/build_worker_image.sh
@@ -8,7 +8,7 @@ create_docker_file()
 
   file="$PWD/Dockerfile"
   cat <<EOF > ${file}
-FROM docker2.molflow.com/devops/arts:10134 AS builder
+FROM odinsmr/arts:10134 AS builder
 COPY data /QsmrData
 # TODO: Fetch from binary repo service?
 COPY qsmr_precalc.tar.gz /qsmr_precalc/qsmr_precalc.tar.gz
@@ -23,7 +23,7 @@ RUN chmod u+x /build_data_artifact.sh
 RUN /build_data_artifact.sh /QsmrData ${INVEMODE} ${FREQMODE}
 RUN rm -r /QsmrData/DataInput
 
-FROM docker2.molflow.com/devops/arts:10134
+FROM odinsmr/arts:10134
 COPY qsmr.tar.gz /qsmr/qsmr.tar.gz
 RUN set -x && \
     cd /qsmr && \
@@ -42,7 +42,7 @@ IMG_TAG=$3
 
 create_docker_file $INVEMODE $FREQMODE
 
-registry="molflow/u-jobs"
+registry="odinsmr/u-jobs"
 worker_image="${registry}:${IMG_TAG}"
 
 docker build --no-cache -t $worker_image .

--- a/Build_scripts/docker/build_worker_image.sh
+++ b/Build_scripts/docker/build_worker_image.sh
@@ -8,7 +8,7 @@ create_docker_file()
 
   file="$PWD/Dockerfile"
   cat <<EOF > ${file}
-FROM odinsmr/arts:10134 AS builder
+FROM odinsmr/arts:2.3.564 AS builder
 COPY data /QsmrData
 # TODO: Fetch from binary repo service?
 COPY qsmr_precalc.tar.gz /qsmr_precalc/qsmr_precalc.tar.gz
@@ -23,7 +23,7 @@ RUN chmod u+x /build_data_artifact.sh
 RUN /build_data_artifact.sh /QsmrData ${INVEMODE} ${FREQMODE}
 RUN rm -r /QsmrData/DataInput
 
-FROM odinsmr/arts:10134
+FROM odinsmr/arts:2.3.564
 COPY qsmr.tar.gz /qsmr/qsmr.tar.gz
 RUN set -x && \
     cd /qsmr && \

--- a/Build_scripts/microq_admin.sh
+++ b/Build_scripts/microq_admin.sh
@@ -1,2 +1,2 @@
 #! /usr/bin/env bash
-docker run --rm -v ~/odin.cfg:/odin.cfg:ro docker2.molflow.com/devops/microq_admin "$@"
+docker run --rm -v ~/odin.cfg:/odin.cfg:ro odinsmr/microq_admin "$@"


### PR DESCRIPTION
the script for building worker images now using odinsmr dockerhub registry.

I have one more PR in a different repo.
https://github.com/molflow/docker/pull/2
that fixes the building of the base image used here, as this was broken.

I have tested that the current PR manage to build a new worker image
using the base image built by in the other PR, so it looks like this
should work.

Resolves #2   